### PR TITLE
add safe to really add .SRCINFO

### DIFF
--- a/aur2aur4.sh
+++ b/aur2aur4.sh
@@ -71,6 +71,7 @@ for package in $list; do
 	pushd $package > /dev/null
 	mksrcinfo
 	git add .
+	git add .SRCINFO -f
 	git commit -m "Initial import"
 	git push origin master
 	popd > /dev/null


### PR DESCRIPTION
this safeguards against users global .gitignore's that ignores dot-files (though force adding may or may not be a good thing...)
